### PR TITLE
Add basic Jekyll website with example content

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -1,0 +1,4 @@
+baseurl: ""
+title: "Sample Jekyll Site"
+author: "Codex Playground"
+description: "A basic Jekyll site with example content"

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{{ page.title }} - {{ site.title }}</title>
+</head>
+<body>
+  <header>
+    <h1><a href="{{ '/' | relative_url }}">{{ site.title }}</a></h1>
+    <nav>
+      <a href="{{ '/' | relative_url }}">Home</a> |
+      <a href="{{ '/about' | relative_url }}">About</a>
+    </nav>
+  </header>
+  <main>
+    {{ content }}
+  </main>
+</body>
+</html>

--- a/website/_layouts/post.html
+++ b/website/_layouts/post.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+
+<article>
+  <h2>{{ page.title }}</h2>
+  {{ content }}
+</article>

--- a/website/_posts/2024-06-09-welcome.md
+++ b/website/_posts/2024-06-09-welcome.md
@@ -1,0 +1,6 @@
+---
+layout: post
+title: "Welcome to the Jekyll Site"
+---
+
+This is the first post on the sample Jekyll site. Posts are stored in the `_posts` directory and use the `YYYY-MM-DD-title.md` naming convention.

--- a/website/about.md
+++ b/website/about.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: About
+---
+
+This page provides information about the sample Jekyll site and its purpose.

--- a/website/index.md
+++ b/website/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Home
+---
+
+Welcome to the sample Jekyll site. This homepage showcases how to structure a simple website using Jekyll.


### PR DESCRIPTION
## Summary
- scaffold a simple Jekyll site under `website/`
- add default and post layouts, basic home & about pages, and a sample blog post

## Testing
- `pytest`
- `gem install bundler jekyll` *(fails: 403 "Forbidden")*
- `bundle exec jekyll build --destination _site` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6890bb32ea58832893f8dc86f29191f7